### PR TITLE
멘티-과제목록 페이지 UI 구현

### DIFF
--- a/src/pages/mainPage/Main.js
+++ b/src/pages/mainPage/Main.js
@@ -10,7 +10,7 @@ import { useOutletContext } from "react-router-dom";
 
 const Main = () => {
   const [isModalOpen, setIsModalOpen] = useOutletContext();
-  // 고정된 헤더바와 isModalOpen 상태를 공유할 방법 찾아야 함
+
   return (
     <div className="mx-20 min-h-[calc(100vh-110px)] flex flex-col">
       <div className="flex gap-14 mx-1">

--- a/src/pages/mentor&menteePage/components/AssignmentsListPageAssignment.js
+++ b/src/pages/mentor&menteePage/components/AssignmentsListPageAssignment.js
@@ -1,0 +1,71 @@
+import React, { useState } from "react";
+import { VscTriangleDown } from "react-icons/vsc";
+import { VscTriangleUp } from "react-icons/vsc";
+import { FaRegCircle } from "react-icons/fa";
+import { PiTriangleBold } from "react-icons/pi";
+import { IoClose } from "react-icons/io5";
+import { FaCheck } from "react-icons/fa";
+import { FaBookmark } from "react-icons/fa";
+
+const AssignmentsListPageAssignment = ({ type }) => {
+  const [showDescription, setShowDescription] = useState(false);
+
+  const dct = {
+    done: <FaRegCircle color="#54CEA6" size={20} />,
+    undone: <IoClose color="#FF6E6E" size={28} />,
+    halfDone: <PiTriangleBold color="#FF6E6E" size={23} />,
+    gotFeedback: <FaBookmark color="#FF6E6E" size={25} />,
+    gaveFeedbackAll: <FaCheck color="#54CEA6" size={23} />,
+    notGaveFeedbackAll: <PiTriangleBold color="#FF6E6E" size={23} />,
+    gaveFeedbackFew: <IoClose color="#FF6E6E" size={28} />,
+  };
+
+  const icon = dct[type];
+
+  return (
+    <div
+      className={`border-2 rounded-xl w-[50rem] py-[0.7rem] px-3 cursor-pointer ${
+        type === "gotFeedback"
+          ? "border-darkRed bg-lightRed"
+          : showDescription
+          ? "border-lightMint bg-white"
+          : "border-gray bg-[#F5F5F5]"
+      }`}
+    >
+      <div className="flex items-center gap-3">
+        <div className="w-8 flex justify-center">{icon}</div>
+        <div className="text-lightBlack font-semibold text-lg">
+          별 찍기 과제
+        </div>
+        <div className="flex-grow flex justify-end items-center">
+          <button
+            onClick={(e) => {
+              e.stopPropagation(); // 이벤트 버블링 방지
+              setShowDescription((prev) => !prev);
+            }}
+          >
+            {showDescription ? (
+              <VscTriangleUp
+                color={type === "gotFeedback" ? "#FF8B8B" : "#a8e6cf"}
+                size={25}
+              />
+            ) : (
+              <VscTriangleDown
+                color={type === "gotFeedback" ? "#FF8B8B" : "#c4c4c4"}
+                size={25}
+              />
+            )}
+          </button>
+        </div>
+      </div>
+      {showDescription && (
+        <div className="text-lightBlack pt-3 pb-1 px-3">
+          Answer the frequently asked question in s simple sentences, a longish
+          aragraph, or even in a list.asdf asdfasd fasdf fadds
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AssignmentsListPageAssignment;

--- a/src/pages/mentor&menteePage/components/CommonComponent.js
+++ b/src/pages/mentor&menteePage/components/CommonComponent.js
@@ -4,16 +4,18 @@ import studyIcon2_1 from "../../../images/studyIcon2-1.png";
 import studyIcon2_2 from "../../../images/studyIcon2-2.png";
 import studyIcon3 from "../../../images/studyIcon3.png";
 import { FaChevronRight } from "react-icons/fa";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 
 const CommonComponent = ({ children, componentTitle }) => {
+  const pathname = useLocation().pathname;
   const dct = {
-    "전체 과제": studyIcon1,
-    "과제 생성": studyIcon2_1,
-    "내가 제출한 과제": studyIcon2_2,
-    "과제 피드백하기": studyIcon3,
+    "전체 과제": [studyIcon1, `${pathname}/assignments`],
+    "과제 생성": [studyIcon2_1],
+    "내가 제출한 과제": [studyIcon2_2],
+    "과제 피드백하기": [studyIcon3],
   };
-  const studyIcon = dct[componentTitle];
+  const studyIcon = dct[componentTitle][0];
+  const linkAddress = dct[componentTitle][1];
 
   return (
     <div className="rounded-2xl border-2 border-darkMint flex-1 flex flex-col items-center py-8">
@@ -32,7 +34,10 @@ const CommonComponent = ({ children, componentTitle }) => {
         </div>
       ) : (
         <div>
-          <Link className="flex items-center justify-end px-3 mb-2">
+          <Link
+            to={linkAddress}
+            className="flex items-center justify-end px-3 mb-2"
+          >
             <div className="text-studyComponentBlack font-semibold">더보기</div>
             <FaChevronRight size={15} color="#686868" />
           </Link>

--- a/src/pages/mentor&menteePage/components/MainPageAssignment.js
+++ b/src/pages/mentor&menteePage/components/MainPageAssignment.js
@@ -21,7 +21,7 @@ const Assignment = ({ type }) => {
 
   return (
     <div className="flex items-center gap-3 border-2 border-gray rounded-xl bg-[#F5F5F5] w-[18rem] py-[0.7rem] px-3 cursor-pointer">
-      {icon}
+      <div className="w-8 flex justify-center">{icon}</div>
       <div className="text-lightBlack font-semibold text-lg">별 찍기 과제</div>
       <div className="flex-grow flex justify-end items-center">
         <VscTriangleRight color="#c4c4c4" size={25} />

--- a/src/pages/mentor&menteePage/menteePage/menteeAssignmentsListPage/MenteeAssignmentsListPage.js
+++ b/src/pages/mentor&menteePage/menteePage/menteeAssignmentsListPage/MenteeAssignmentsListPage.js
@@ -1,0 +1,21 @@
+import React from "react";
+import AssignmentsListPageAssignment from "../../components/AssignmentsListPageAssignment";
+
+// 멘티 과제 목록 페이지에서의 Assignment컴포넌트의 type
+// done / undone / gotFeedback
+
+const MenteeAssignmentsListPage = () => {
+  return (
+    <div className="flex flex-col items-center justify-center mt-5 mb-10">
+      <div className="text-lightBlack text-3xl p-14">과제</div>
+      <div className="flex flex-col gap-5">
+        <AssignmentsListPageAssignment type={"done"} />
+        <AssignmentsListPageAssignment type={"undone"} />
+        <AssignmentsListPageAssignment type={"gotFeedback"} />
+        <AssignmentsListPageAssignment type={"undone"} />
+      </div>
+    </div>
+  );
+};
+
+export default MenteeAssignmentsListPage;

--- a/src/pages/mentor&menteePage/menteePage/menteeMainPage/MenteeMainPage.js
+++ b/src/pages/mentor&menteePage/menteePage/menteeMainPage/MenteeMainPage.js
@@ -1,7 +1,7 @@
 import React from "react";
 import CommonMainComponent from "../../components/CommonMainTitle";
 import CommonComponent from "../../components/CommonComponent";
-import Assignment from "../../components/MainPageAssignment";
+import MainPageAssignment from "../../components/MainPageAssignment";
 
 // 멘티 페이지에서의 Assignment컴포넌트의 type
 // 전체 과제 -> done / undone
@@ -14,19 +14,19 @@ const MenteeMainPage = () => {
       <CommonMainComponent />
       <div className="flex gap-5 mt-3">
         <CommonComponent componentTitle={"전체 과제"}>
-          <Assignment type={"done"} />
-          <Assignment type={"undone"} />
-          <Assignment type={"done"} />
+          <MainPageAssignment type={"done"} />
+          <MainPageAssignment type={"undone"} />
+          <MainPageAssignment type={"done"} />
         </CommonComponent>
         <CommonComponent componentTitle={"내가 제출한 과제"}>
-          <Assignment type={"done"} />
-          <Assignment type={"done"} />
-          <Assignment type={"done"} />
+          <MainPageAssignment type={"done"} />
+          <MainPageAssignment type={"done"} />
+          <MainPageAssignment type={"done"} />
         </CommonComponent>
         <CommonComponent componentTitle={"과제 피드백하기"}>
-          <Assignment type={"gotFeedback"} />
-          <Assignment type={"gotFeedback"} />
-          <Assignment type={"gotFeedback"} />
+          <MainPageAssignment type={"gotFeedback"} />
+          <MainPageAssignment type={"gotFeedback"} />
+          <MainPageAssignment type={"gotFeedback"} />
         </CommonComponent>
       </div>
     </div>

--- a/src/pages/mentor&menteePage/mentorPage/mentorMainPage/MentorMainPage.js
+++ b/src/pages/mentor&menteePage/mentorPage/mentorMainPage/MentorMainPage.js
@@ -1,6 +1,6 @@
 import React from "react";
 import CommonMainComponent from "../../components/CommonMainTitle";
-import Assignment from "../../components/MainPageAssignment";
+import MainPageAssignment from "../../components/MainPageAssignment";
 import CommonComponent from "../../components/CommonComponent";
 
 // 멘토 페이지에서의 Assignment컴포넌트의 type
@@ -13,15 +13,15 @@ const MentorMainPage = () => {
       <CommonMainComponent />
       <div className="flex gap-5 mt-3">
         <CommonComponent componentTitle={"전체 과제"}>
-          <Assignment type={"done"} />
-          <Assignment type={"undone"} />
-          <Assignment type={"halfDone"} />
+          <MainPageAssignment type={"done"} />
+          <MainPageAssignment type={"undone"} />
+          <MainPageAssignment type={"halfDone"} />
         </CommonComponent>
         <CommonComponent componentTitle={"과제 생성"} />
         <CommonComponent componentTitle={"과제 피드백하기"}>
-          <Assignment type={"gaveFeedbackAll"} />
-          <Assignment type={"notGaveFeedbackAll"} />
-          <Assignment type={"gaveFeedbackFew"} />
+          <MainPageAssignment type={"gaveFeedbackAll"} />
+          <MainPageAssignment type={"notGaveFeedbackAll"} />
+          <MainPageAssignment type={"gaveFeedbackFew"} />
         </CommonComponent>
       </div>
     </div>

--- a/src/routes/AppRouter.js
+++ b/src/routes/AppRouter.js
@@ -7,6 +7,7 @@ import Error from "../pages/errorPage/Error";
 import PostHeader from "../pages/headers/PostHeader";
 import MentorMainPage from "../pages/mentor&menteePage/mentorPage/mentorMainPage/MentorMainPage";
 import MenteeMainPage from "../pages/mentor&menteePage/menteePage/menteeMainPage/MenteeMainPage";
+import MenteeAssignmentsListPage from "../pages/mentor&menteePage/menteePage/menteeAssignmentsListPage/MenteeAssignmentsListPage";
 
 const AppRouter = () => {
   const router = createBrowserRouter([
@@ -48,6 +49,10 @@ const AppRouter = () => {
         {
           path: "",
           element: <MenteeMainPage />,
+        },
+        {
+          path: "assignments",
+          element: <MenteeAssignmentsListPage />,
         },
       ],
     },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,8 @@ module.exports = {
         studyComponentBlack: "#686868",
         realLightMint: "#8DE5E6",
         gray: "#C4C4C4",
+        darkRed: "#FF8B8B",
+        lightRed: "#FFF4F4",
       },
     },
   },


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #25 

## 📝작업 내용

> 멘티 화면 입장에서의 과제목록 페이지 UI 구현

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/47756938-34da-41f3-9d1a-20c0a4127cd7)
